### PR TITLE
Add Architectures section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Types: deb
 URIs: https://xlibre-debian.github.io/devuan/
 Suites: main
 Components: stable
-Architectures: amd64
+Architectures: amd64 arm64
 Signed-By: /usr/share/keyrings/NexusSfan.pgp
 EOF
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Types: deb
 URIs: https://xlibre-debian.github.io/devuan/
 Suites: main
 Components: stable
+Architectures: amd64
 Signed-By: /usr/share/keyrings/NexusSfan.pgp
 EOF
 


### PR DESCRIPTION
Solves: 
Notice: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'https://xlibre-debian.github.io/devuan main InRelease' doesn't support architecture 'i386'

The xlibre repo does not support the i386 architecture, thus it shows this message every time you `sudo apt update`, which is kinda annoying.